### PR TITLE
fixed mixed content elements and CDATA attribute lists in dtd, changed <def> semantics

### DIFF
--- a/format_standard/xdxf_strict.dtd
+++ b/format_standard/xdxf_strict.dtd
@@ -1,6 +1,6 @@
 <!ELEMENT xdxf (meta_info,lexicon)>
     <!ATTLIST xdxf format (visual|logical) "logical">
-    <!ATTLIST xdxf revision (#PCDATA) #REQUIRED>
+    <!ATTLIST xdxf revision CDATA #REQUIRED>
 
 <!ELEMENT meta_info (title,full_title,description,publisher?,authors?,file_ver,creation_date,last_edited_date?,dict_edition?,publishing_date?,dict_src_url?,abbreviations?)>
 <!ELEMENT title (#PCDATA)>
@@ -9,7 +9,7 @@
 <!ELEMENT publisher (#PCDATA)>
 <!ELEMENT authors (author+)>
 <!ELEMENT author (#PCDATA)>
-    <!ATTLIST author role (#PCDATA) #IMPLIED>
+    <!ATTLIST author role CDATA #IMPLIED>
 
 <!ELEMENT file_ver (#PCDATA)>
 <!ELEMENT creation_date (#PCDATA)>
@@ -26,34 +26,34 @@
 <!ELEMENT lexicon (ar+)>
 <!ELEMENT ar (k+,def) >
     <!ATTLIST ar f (v|l) "l">
-<!ELEMENT k (#PCDATA|opt|sup|sub) >
+<!ELEMENT k (#PCDATA|opt|sup|sub)* >
 <!ELEMENT opt (#PCDATA)>
-<!ELEMENT def ((gr?,tr*,rref*,def+,ex*,sr?,etm?,categ*)|(gr?,tr*,(#PCDATA,dtrn|kref|rref|iref|abbr|c|ex|co|i|b|gr)*,sr?,etm?,categ*)) >
+<!ELEMENT def (#PCDATA|def|gr|tr|dtrn|kref|rref|iref|abbr|c|ex|co|i|b|sr|etm|categ)* >
     <!ATTLIST def id ID #IMPLIED>
-    <!ATTLIST def cmt #PCDATA #IMPLIED>
-    <!ATTLIST def freq #PCDATA #IMPLIED>
+    <!ATTLIST def cmt CDATA #IMPLIED>
+    <!ATTLIST def freq CDATA #IMPLIED>
 <!ELEMENT sr (kref+)>
-<!ELEMENT etm (#PCDATA|kref|c|sup|sub|i|b)>
+<!ELEMENT etm (#PCDATA|kref|c|sup|sub|i|b)* >
 <!ELEMENT categ (#PCDATA)>
 <!ELEMENT gr (#PCDATA|abbr)* >
 <!ELEMENT tr (#PCDATA)>
     <!ATTLIST tr format (IPA|X-SAMPA|erkIPA) "IPA">
 <!ELEMENT dtrn (#PCDATA|sup|sub|i|b)* >
-<!ELEMENT kref (#PCDATA|dtrn|sup|sub)>
+<!ELEMENT kref (#PCDATA|dtrn|sup|sub)* >
     <!ATTLIST kref idref IDREF #IMPLIED>
     <!ATTLIST kref type (syn|ant|hpr|hpn|par|spv|mer|hol|ent|rel|etm) #IMPLIED>
-    <!ATTLIST kref kcmt (#PCDATA) #IMPLIED>
+    <!ATTLIST kref kcmt CDATA #IMPLIED>
 <!ELEMENT rref (#PCDATA)>
-    <!ATTLIST rref start (#PCDATA) "0">
-    <!ATTLIST rref size (#PCDATA) #IMPLIED>
+    <!ATTLIST rref start CDATA "0">
+    <!ATTLIST rref size CDATA #IMPLIED>
 <!ELEMENT iref (#PCDATA)>
-    <!ATTLIST iref href (#PCDATA) #REQUIRED>
+    <!ATTLIST iref href CDATA #REQUIRED>
 <!ELEMENT abbr (#PCDATA)>
 <!ELEMENT ex (ex_orig*,ex_transl*) >
     <!ATTLIST ex type (exm|phr|prv|oth) "exm">
-    <!ATTLIST ex source (#PCDATA) #IMPLIED>
-    <!ATTLIST ex author (#PCDATA) #IMPLIED>
-<!ELEMENT ex_orig (#PCDATA|mrkd|kref|co|sup|sub|i|b)+ >
+    <!ATTLIST ex source CDATA #IMPLIED>
+    <!ATTLIST ex author CDATA #IMPLIED>
+<!ELEMENT ex_orig (#PCDATA|mrkd|kref|co|sup|sub|i|b)* >
 <!ELEMENT ex_transl (#PCDATA|mrkd|kref|co|sup|sub|i|b)* >
 <!ELEMENT mrkd (#PCDATA) >
 <!ELEMENT co (#PCDATA|kref|c|sup|sub|i|b)* >


### PR DESCRIPTION
* fixed [mixed content elements](http://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content) syntax according to W3C Recommendations
* fixed [attributes with character data type](http://www.w3.org/TR/2008/REC-xml-20081126/#NT-StringType) according to W3C Recommendations
* PROBLEM! changed semantics of ```<def>```-element because of it being a mixed content element

I understand the main point of the old <def> definition, is that if an article definition contains character data, then it can't contain a nested ```<def>```. I couldn't express this as a DTD element constrain, though. Any ideas?